### PR TITLE
feat: add native Skeleton Loader to UI library

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -48,6 +48,7 @@
     "expo-asset": "10.0.6",
     "expo-constants": "16.0.2",
     "expo-font": "12.0.5",
+    "expo-linear-gradient": "13.0.2",
     "expo-splash-screen": "0.27.4",
     "metro-cache": "0.80.5",
     "metro-config": "0.80.5",
@@ -55,6 +56,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-native": "0.74.1",
+    "react-native-reanimated": "3.10.1",
     "react-native-svg": "15.2.0"
   },
   "devDependencies": {

--- a/packages/ui/src/components/skeleton-loader/skeleton-loader.native.stories.tsx
+++ b/packages/ui/src/components/skeleton-loader/skeleton-loader.native.stories.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from 'react';
+import { View } from 'react-native';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { ANIMATION_DURATION, SkeletonLoader } from './skeleton-loader.native';
+
+type SkeletonLoaderArgs = React.ComponentProps<typeof SkeletonLoader>;
+
+type Story = StoryObj<SkeletonLoaderArgs>;
+
+const meta: Meta<SkeletonLoaderArgs> = {
+  title: 'Skeleton Loader',
+  component: SkeletonLoader,
+  decorators: [
+    Story => (
+      <View style={{ alignItems: 'center', justifyContent: 'center', flex: 1 }}>
+        <Story />
+      </View>
+    ),
+  ],
+};
+
+export default meta;
+
+export const SkeletonLoaderStory: Story = {
+  args: {
+    isLoading: true,
+    width: 200,
+    height: 38,
+  },
+};
+
+export const SkeletonLoaderRoundStory: Story = {
+  args: {
+    isLoading: true,
+    width: 200,
+    height: 200,
+    borderRadius: 'round',
+  },
+};
+
+export const SkeletonLoaderMultipleStory: Story = {
+  args: {
+    isLoading: true,
+    width: 200,
+    height: 38,
+  },
+  render: (props => {
+    const [showCount, setShowCount] = useState(1);
+
+    useEffect(() => {
+      let count = 1;
+      let step = 1;
+      const maxCount = 5;
+
+      const interval = setInterval(() => {
+        count += step;
+        setShowCount(count);
+        if (count === maxCount || count === 1) {
+          step *= -1;
+        }
+      }, 1.5 * ANIMATION_DURATION);
+
+      return () => clearInterval(interval);
+    }, []);
+
+    return (
+      <View style={{ alignItems: 'center', justifyContent: 'center', flex: 1, gap: 5 }}>
+        {[...Array(showCount)].map((_, index) => (
+          <SkeletonLoader key={index} {...props} />
+        ))}
+      </View>
+    );
+  }) satisfies React.FC<SkeletonLoaderArgs>,
+};

--- a/packages/ui/src/components/skeleton-loader/skeleton-loader.native.tsx
+++ b/packages/ui/src/components/skeleton-loader/skeleton-loader.native.tsx
@@ -1,0 +1,94 @@
+import { useLayoutEffect } from 'react';
+import { StyleSheet } from 'react-native';
+import Animated, {
+  Easing,
+  interpolate,
+  useAnimatedStyle,
+  useSharedValue,
+  withRepeat,
+  withSequence,
+  withTiming,
+} from 'react-native-reanimated';
+
+import { useTheme } from '@shopify/restyle';
+import { LinearGradient } from 'expo-linear-gradient';
+
+import { Box } from '../box/box.native';
+
+const AnimatedLinearGradient = Animated.createAnimatedComponent(LinearGradient);
+
+export const ANIMATION_DURATION = 1_000;
+const ANIMATION_EASING = Easing.ease;
+const LEFT_POS_START = -100;
+const LEFT_POS_END = 100;
+
+function SkeletonLoaderAnimation(props: React.ComponentProps<typeof Box>) {
+  const theme = useTheme();
+  const animatedLeft = useSharedValue(LEFT_POS_START);
+
+  const color = theme.colors['ink.text-non-interactive'];
+
+  useLayoutEffect(() => {
+    const animationProgress = Date.now() % ANIMATION_DURATION;
+    const initialLeftPos = interpolate(
+      animationProgress,
+      [0, ANIMATION_DURATION],
+      [LEFT_POS_START, LEFT_POS_END]
+    );
+
+    // start animation from the interpolated position (synced with other loaders) and then repeat
+    animatedLeft.value = withSequence(
+      withTiming(initialLeftPos, { duration: 0 }),
+      withTiming(LEFT_POS_END, {
+        duration: ANIMATION_DURATION - animationProgress,
+        easing: ANIMATION_EASING,
+      }),
+      withTiming(LEFT_POS_START, { duration: 0 }),
+      withRepeat(
+        withTiming(LEFT_POS_END, { duration: ANIMATION_DURATION, easing: ANIMATION_EASING }),
+        -1
+      )
+    );
+  }, []);
+
+  const animatedStyles = useAnimatedStyle(() => {
+    return {
+      left: `${animatedLeft.value}%`,
+      backgroundColor: color,
+    };
+  });
+
+  return (
+    <Box backgroundColor="ink.text-non-interactive" borderRadius="sm" {...props} overflow="hidden">
+      <AnimatedLinearGradient
+        colors={[color, 'rgba(255, 255, 255, 0.75)', color]}
+        start={{ x: 0.1, y: 1 }}
+        end={{ x: 0.9, y: 1 }}
+        style={[styles.gradientAnimation, animatedStyles]}
+      />
+    </Box>
+  );
+}
+
+interface SkeletonLoaderProps extends React.ComponentProps<typeof Box> {
+  isLoading: boolean;
+  children?: React.ReactNode;
+}
+
+export function SkeletonLoader({ children, isLoading, ...rest }: SkeletonLoaderProps) {
+  if (isLoading) {
+    return <SkeletonLoaderAnimation {...rest} />;
+  }
+
+  return children;
+}
+
+const styles = StyleSheet.create({
+  gradientAnimation: {
+    position: 'absolute',
+    width: '100%',
+    top: '-50%',
+    height: '200%',
+    transform: [{ rotateZ: '15deg' }],
+  },
+});


### PR DESCRIPTION
This PR adds a native Skeleton Loader to the UI library, replicating the same animation as the existing web component.

To achieve this, the libraries react-native-reanimated and expo-linear-gradient have been included in the UI package.

Web, iOS and Android storybooks:

https://github.com/user-attachments/assets/2ee070c0-5f3d-4a98-9547-b2d725a129e8

